### PR TITLE
Backward compatibility with Laravel 5.2 and Laravel 5.3

### DIFF
--- a/src/Command/BaseConsumerCommand.php
+++ b/src/Command/BaseConsumerCommand.php
@@ -37,7 +37,7 @@ class BaseConsumerCommand extends Command
      */
     protected function getConsumer(string $consumerAliasName): ConsumerInterface
     {
-        return app()->makeWith(ConsumerInterface::class, [$consumerAliasName]);
+        return app()->make(ConsumerInterface::class, [$consumerAliasName]);
     }
 
     /**

--- a/src/Providers/ServiceProvider.php
+++ b/src/Providers/ServiceProvider.php
@@ -33,17 +33,25 @@ class ServiceProvider extends LaravelServiceProvider
     protected $defer = false;
 
     /**
+     * Register services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->registerContainer();
+        $this->registerPublishers();
+        $this->registerConsumers();
+    }
+
+    /**
      * Perform post-registration booting of services.
      *
      * @return void
-     * @throws LaravelRabbitMqException
      */
     public function boot()
     {
         $this->publishConfig();
-        $this->registerContainer();
-        $this->registerPublishers();
-        $this->registerConsumers();
         $this->registerCommands();
     }
 


### PR DESCRIPTION
* Prefer make() to makeWith() for backward compatibility with Laravel 5.3 (makeWith() is an alias for make() anyway)
* Implement abstract register() method in base service provider