### PR TITLE
Fix provider for Lumen

### DIFF
--- a/src/Providers/ServiceProvider.php
+++ b/src/Providers/ServiceProvider.php
@@ -96,7 +96,7 @@ class ServiceProvider extends LaravelServiceProvider
     private function registerPublishers()
     {
         // Get "tagged" like Publisher
-        $this->app->singleton(PublisherInterface::class, function (Application $application, $arguments) {
+        $this->app->singleton(PublisherInterface::class, function ($application, $arguments) {
             /** @var Container $container */
             $container = $application->make(Container::class);
             if (empty($arguments)) {
@@ -113,7 +113,7 @@ class ServiceProvider extends LaravelServiceProvider
     private function registerConsumers()
     {
         // Get "tagged" like Consumers
-        $this->app->singleton(ConsumerInterface::class, function (Application $application, $arguments) {
+        $this->app->singleton(ConsumerInterface::class, function ($application, $arguments) {
             /** @var Container $container */
             $container = $application->make(Container::class);
             if (empty($arguments)) {


### PR DESCRIPTION
An error occurs in the Lumen:
```
Argument 1 passed to NeedleProject\LaravelRabbitMq\Providers\ServiceProvider::NeedleProject\LaravelRabbitMq\Providers\{closure}() must be an instance of Illuminate\Foundation\Application, instance of Laravel\Lumen\Application given
```

This fix fixes the error and makes the code compatible with Lumen